### PR TITLE
Fix comments in examples

### DIFF
--- a/examples/example3.json.txt
+++ b/examples/example3.json.txt
@@ -40,7 +40,7 @@ be9d-e663e4d41ffe /,
                             / directive-override-parameters / 20,{
                                 / offset / 5:33792,
                             } ,
-                            / condition-component-offset / 5,5 ,
+                            / condition-component-slot / 5,5 ,
                             / directive-override-parameters / 20,{
                                 / image-digest / 3:<<[
                                     / algorithm-id / -16 / "sha256" /,
@@ -54,7 +54,7 @@ h'00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210'
                             / directive-override-parameters / 20,{
                                 / offset / 5:541696,
                             } ,
-                            / condition-component-offset / 5,5 ,
+                            / condition-component-slot / 5,5 ,
                             / directive-override-parameters / 20,{
                                 / image-digest / 3:<<[
                                     / algorithm-id / -16 / "sha256" /,
@@ -75,7 +75,7 @@ h'0123456789abcdeffedcba987654321000112233445566778899aabbccddeeff'
                         / directive-set-parameters / 19,{
                             / offset / 5:33792,
                         } ,
-                        / condition-component-offset / 5,5 ,
+                        / condition-component-slot / 5,5 ,
                         / directive-set-parameters / 19,{
                             / uri / 21:'http://example.com/file1.bin',
                         }
@@ -84,7 +84,7 @@ h'0123456789abcdeffedcba987654321000112233445566778899aabbccddeeff'
                         / directive-set-parameters / 19,{
                             / offset / 5:541696,
                         } ,
-                        / condition-component-offset / 5,5 ,
+                        / condition-component-slot / 5,5 ,
                         / directive-set-parameters / 19,{
                             / uri / 21:'http://example.com/file2.bin',
                         }

--- a/examples/example4.json.txt
+++ b/examples/example4.json.txt
@@ -79,7 +79,7 @@ h'0123456789abcdeffedcba987654321000112233445566778899aabbccddeeff'
                     / image-size / 14:76834,
                     / source-component / 22:0 / [h'00'] /,
                     / compression-info / 19:<<{
-                        / compression-algorithm / 1:1 / "gzip" /,
+                        / compression-algorithm / 1:1 / "zlib" /,
                     }>>,
                 } ,
                 / directive-copy / 22,2 ,

--- a/examples/example7.json.txt
+++ b/examples/example7.json.txt
@@ -40,7 +40,7 @@ be9d-e663e4d41ffe /,
                             / directive-override-parameters / 20,{
                                 / offset / 5:33792,
                             } ,
-                            / condition-component-offset / 5,5 ,
+                            / condition-component-slot / 5,5 ,
                             / directive-override-parameters / 20,{
                                 / image-digest / 3:<<[
                                     / algorithm-id / -16 / "sha256" /,
@@ -54,7 +54,7 @@ h'00112233445566778899aabbccddeeff0123456789abcdeffedcba9876543210'
                             / directive-override-parameters / 20,{
                                 / offset / 5:541696,
                             } ,
-                            / condition-component-offset / 5,5 ,
+                            / condition-component-slot / 5,5 ,
                             / directive-override-parameters / 20,{
                                 / image-digest / 3:<<[
                                     / algorithm-id / -16 / "sha256" /,
@@ -75,7 +75,7 @@ h'0123456789abcdeffedcba987654321000112233445566778899aabbccddeeff'
                         / directive-set-parameters / 19,{
                             / offset / 5:33792,
                         } ,
-                        / condition-component-offset / 5,5 ,
+                        / condition-component-slot / 5,5 ,
                         / directive-set-parameters / 19,{
                             / uri / 21:'http://example.com/file1.bin',
                         }
@@ -84,7 +84,7 @@ h'0123456789abcdeffedcba987654321000112233445566778899aabbccddeeff'
                         / directive-set-parameters / 19,{
                             / offset / 5:541696,
                         } ,
-                        / condition-component-offset / 5,5 ,
+                        / condition-component-slot / 5,5 ,
                         / directive-set-parameters / 19,{
                             / uri / 21:'http://example.com/file2.bin',
                         }


### PR DESCRIPTION
This PR just fixes comments in each example to follow the manifest-spec updates.

| from | to | in |related commit |
|--|--|--|--|
| "gzip" | "zlib" | example4 | 64869cb6da72994ea7ff2914e1becd3c188e9566 |
| component-offset | component-slot | example3 and example 7 | 1d9a6a854dd67fc30f895b06b8479b87045d9021 |