### PR TITLE
Removed COSWID in CDDL

### DIFF
--- a/draft-ietf-suit-manifest.cddl
+++ b/draft-ietf-suit-manifest.cddl
@@ -29,7 +29,6 @@ SUIT_Severable_Manifest_Members = (
   ? suit-payload-fetch => bstr .cbor SUIT_Command_Sequence,
   ? suit-install => bstr .cbor SUIT_Command_Sequence,
   ? suit-text => bstr .cbor SUIT_Text_Map,
-  ? suit-coswid => bstr .cbor concise-software-identity,
   * $$SUIT_severable-members-extensions,
 )
 


### PR DESCRIPTION
Removed COSWID from the manifest draft to have it included in an extension document. 