### PR TITLE
Removed COSWID in Manifest draft

### DIFF
--- a/draft-ietf-suit-manifest.md
+++ b/draft-ietf-suit-manifest.md
@@ -264,9 +264,9 @@ The diagram below illustrates the hierarchy of the Envelope.
 | Manifest           --------------> +------------------------------+
 | Severable Elements      |          | Manifest                     |
 | Human-Readable Text     |          +------------------------------+
-| COSWID                  |          | Structure Version            |
-| Integrated Payloads     |          | Sequence Number              |
-+-------------------------+          | Reference to Full Manifest   |
+| Integrated Payloads     |          | Structure Version            |
++-------------------------+          | Sequence Number              |
+                                     | Reference to Full Manifest   |
                                +------ Common Structure             |
                                | +---- Command Sequences            |
 +-------------------------+    | |   | Digests of Envelope Elements |


### PR DESCRIPTION
Removed COSWID from the manifest draft to have it included in an extension document. 
