### PR TITLE
[hackathon-ietf112] Adding Makefile for generaing txt and xml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+DRAFT = draft-ietf-suit-manifest
+FN := $(shell grep 'docname: $(DRAFT)' $(DRAFT).md | awk '{print $$2}')
+
+$(FN).txt: $(FN).xml
+	xml2rfc $(FN).xml
+
+$(FN).xml: $(DRAFT).md
+	kramdown-rfc2629 $(DRAFT).md > $(FN).xml
+
+.PHONY: clean
+clean:
+	rm -fr $(FN).txt $(FN).xml


### PR DESCRIPTION
Just type make on command line will generate xml and txt file from the md file.
Which is convenient for check the md file for the draft format.

It was created during the IETF112 hackathon for creating my PR in suit cddl.

Signed-off-by: Akira Tsukamoto <akira.tsukamoto@aist.go.jp>