### PR TITLE
[hackathon-ietf112] Adding cose algorithm value used in the examples

### DIFF
--- a/draft-ietf-suit-manifest.cddl
+++ b/draft-ietf-suit-manifest.cddl
@@ -102,6 +102,7 @@ suit-cose-hash-algs /= cose-alg-shake128
 suit-cose-hash-algs /= cose-alg-sha-384
 suit-cose-hash-algs /= cose-alg-sha-512
 suit-cose-hash-algs /= cose-alg-shake256
+suit-cose-asym-algs /= cose-alg-es256
 
 SUIT_Component_Identifier =  [* bstr]
 


### PR DESCRIPTION
The value in the exampels bellow are -7 for es256
```
            digest: <<[
                / algorithm-id / -16 / "sha256" /,
                / digest-bytes /
            ]>>,
            signature: <<18([
                    / protected / <<{
                        / alg / 1:-7 / "ES256" /,
                    }>>,
```

Just adding the es256 to the cddl. The sha256 is already in the cddl.

The cose values are specified at
https://www.iana.org/assignments/cose/cose.xhtml


Signed-off-by: Akira Tsukamoto <akira.tsukamoto@aist.go.jp>