### PR TITLE
Proposed improvements for the CDDL (#48)

### DIFF
--- a/draft-ietf-suit-manifest.cddl
+++ b/draft-ietf-suit-manifest.cddl
@@ -6,7 +6,6 @@ SUIT_Envelope = {
   SUIT_Severable_Manifest_Members,
   * SUIT_Integrated_Payload,
   * $$SUIT_Envelope_Extensions,
-  * (int => bstr)
 }
 
 SUIT_Authentication = [
@@ -42,8 +41,8 @@ SUIT_Manifest = {
     suit-manifest-sequence-number => uint,
     suit-common                   => bstr .cbor SUIT_Common,
     ? suit-reference-uri          => tstr,
-    SUIT_Severable_Members_Choice,
     SUIT_Unseverable_Members,
+    SUIT_Severable_Members_Choice,
     * $$SUIT_Manifest_Extensions,
 }
 
@@ -93,15 +92,21 @@ SUIT_Common_Sequence = [
 
 SUIT_Common_Commands //= (suit-directive-set-component-index,  IndexArg)
 SUIT_Common_Commands //= (suit-directive-run-sequence,
-    bstr .cbor SUIT_Command_Sequence)
+    bstr .cbor SUIT_Common_Sequence)
 SUIT_Common_Commands //= (suit-directive-try-each,
-    SUIT_Directive_Try_Each_Argument)
+    SUIT_Directive_Try_Each_Argument_Common)
 SUIT_Common_Commands //= (suit-directive-override-parameters,
     {+ SUIT_Parameters})
 
 IndexArg /= uint
 IndexArg /= bool
 IndexArg /= [+uint]
+
+
+SUIT_Directive_Try_Each_Argument_Common = [
+    2* bstr .cbor SUIT_Common_Sequence,
+    ?nil
+]
 
 SUIT_Command_Sequence = [ + (
     SUIT_Condition // SUIT_Directive // SUIT_Command_Custom
@@ -202,16 +207,19 @@ cose-alg-sha-384 = -43
 cose-alg-sha-512 = -44
 cose-alg-shake256 = -45
 
+;Unseverable, recipient-necessary
 suit-manifest-version = 1
 suit-manifest-sequence-number = 2
 suit-common = 3
 suit-reference-uri = 4
-suit-payload-fetch = 8
-suit-install = 9
-suit-validate = 10
-suit-load = 11
-suit-run = 12
-suit-text = 13
+suit-validate = 7
+suit-load = 8
+suit-run = 9
+;Severable, recipient-necessary
+suit-payload-fetch = 16
+suit-install = 17
+;Severable, recipient-unnecessary
+suit-text = 23
 
 suit-components = 2
 suit-common-sequence = 4


### PR DESCRIPTION
* manifest.cddl: Enforce the restriction on common sequence commands in

try-each and run-command-sequence directives.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

* manifest.cddl: Redo manifest member numbers to match the order

they appear in the manifest.
Place all severable members before all unseverable members.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

* manifest.cddl: Remove "* (int => bstr)" in SUIT_Envelope

since it should be covered by $$SUIT_Envelope_Extensions

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

* Correct CDDL ordering

* Update CDDL key values

This commit changes the key values to ensure that canonical CBOR ordering results in the following element order:

1. unseverable, recipient-necessary
2. severable, recipient-necessary
3. unseverable, recipient-unnecessary
4. severable, recipient-unnecessary

Co-authored-by: Brendan Moran <brendan.moran@arm.com>