### PR TITLE
Add suit-parameter-fetch-arguments

### DIFF
--- a/draft-ietf-suit-manifest.cddl
+++ b/draft-ietf-suit-manifest.cddl
@@ -255,7 +255,6 @@ suit-parameter-component-slot    = 5
 suit-parameter-strict-order      = 12
 suit-parameter-soft-failure      = 13
 suit-parameter-image-size        = 14
-suit-parameter-fetch-arguments   = 16
 suit-parameter-content           = 18
 
 suit-parameter-uri               = 21
@@ -263,6 +262,7 @@ suit-parameter-source-component  = 22
 suit-parameter-invoke-args       = 23
 
 suit-parameter-device-identifier = 24
+suit-parameter-fetch-arguments   = 25
 
 suit-parameter-custom = nint
 

--- a/draft-ietf-suit-manifest.cddl
+++ b/draft-ietf-suit-manifest.cddl
@@ -153,6 +153,7 @@ $$SUIT_Parameters //= (suit-parameter-image-size => uint)
 $$SUIT_Parameters //= (suit-parameter-component-slot => uint)
 
 $$SUIT_Parameters //= (suit-parameter-uri => tstr)
+$$SUIT_Parameters //= (suit-parameter-fetch-arguments => bstr)
 $$SUIT_Parameters //= (suit-parameter-source-component => uint)
 $$SUIT_Parameters //= (suit-parameter-invoke-args => bstr)
 
@@ -254,6 +255,7 @@ suit-parameter-component-slot    = 5
 suit-parameter-strict-order      = 12
 suit-parameter-soft-failure      = 13
 suit-parameter-image-size        = 14
+suit-parameter-fetch-arguments   = 16
 suit-parameter-content           = 18
 
 suit-parameter-uri               = 21


### PR DESCRIPTION
Section [8.4.8.13](https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-29#section-8.4.8.13) describes suit-parameter-fetch-arguments but it's not defined in the CDDL part.
I've chose `16` for the value because it's not used in other extension documents, and it's the same value with `suit-payload-fetch` .